### PR TITLE
Documentation, robustness and CI improvements

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,49 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown.yaml
+
+permissions: read-all
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 inst/doc
 /doc/
 /Meta/
+docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,9 +13,10 @@ URL: https://github.com/mrc-ide/malariasimple, https://mrc-ide.github.io/malaria
 BugReports: https://github.com/mrc-ide/malariasimple/issues
 Encoding: UTF-8
 LazyData: true
-Remotes: 
+Remotes:
     mrc-ide/dust2,
-    mrc-ide/monty
+    mrc-ide/monty,
+    mrc-ide/malariasimulation
 Imports: 
     dust2,
     statmod,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,9 +6,11 @@ Authors@R: c(
   person("Debbie", "Shackleton", email="dshackle@imperial.ac.uk", role = c("aut","cre")),
   person("Peter", "Winskill", email="p.winskill@imperial.ac.uk", role = c("aut")))
 Maintainer: Debbie Shackleton <dshackle@imperial.ac.uk>
-Description: A faster, simpler implementation of malariasimulation built using 
+Description: A faster, simpler implementation of malariasimulation built using
     the package 'odin.dust'.
 License: MIT + file LICENSE
+URL: https://github.com/mrc-ide/malariasimple, https://mrc-ide.github.io/malariasimple/
+BugReports: https://github.com/mrc-ide/malariasimple/issues
 Encoding: UTF-8
 LazyData: true
 Remotes: 

--- a/R/post_processing.R
+++ b/R/post_processing.R
@@ -6,7 +6,12 @@
 #' @param output_variable Output variable of interest.
 #' @param ages Age groups of interest (defined by the lower bracket)
 #' @param biting_groups Biting groups of interest
-#' @param int_groups Intervention groups of interest. 1 = No intervention, 2 = Bednets, 3 = SMC, 4 = Bednets and SMC
+#' @param int_groups Intervention groups of interest, given as indices into the
+#'   model's intervention strata (1 = No intervention, 2 = Bednets, 3 = SMC,
+#'   4 = Bednets and SMC). These indices reflect the interventions currently
+#'   supported by the model (ITNs and SMC); adding a new intervention type would
+#'   require extending the intervention structure in `set_equilibrium()` and the
+#'   odin model, after which the index meanings would change accordingly.
 #' @importFrom dplyr mutate
 #' @importFrom reshape2 melt
 
@@ -59,7 +64,12 @@ get_custom <- function(params,
 #' @param output_variables Output variable of interest.
 #' @param ages Age groups of interest (defined by the lower bracket)
 #' @param biting_groups Biting groups of interest
-#' @param int_groups Intervention groups of interest. 1 = No intervention, 2 = Bednets, 3 = SMC, 4 = Bednets and SMC
+#' @param int_groups Intervention groups of interest, given as indices into the
+#'   model's intervention strata (1 = No intervention, 2 = Bednets, 3 = SMC,
+#'   4 = Bednets and SMC). These indices reflect the interventions currently
+#'   supported by the model (ITNs and SMC); adding a new intervention type would
+#'   require extending the intervention structure in `set_equilibrium()` and the
+#'   odin model, after which the index meanings would change accordingly.
 #' @examples
 #'   params <- get_parameters(
 #'     n_days = 50,

--- a/R/set_smc.R
+++ b/R/set_smc.R
@@ -69,6 +69,9 @@ set_smc <- function(params,
   if (!(length(coverages) == 1 |
         length(coverages) == length(days)))
     stop(message("length(coverages) must be either 1 or length(days)"))
+  if (!distribution_type %in% c("random", "correlated")) {
+    stop("distribution_type must be one of 'random' or 'correlated'")
+  }
   days <- round(days) #It's easiest if SMC days are all integer values.
   days <- days + 1 #To account for day 0.
   #----------------------------------- Set Parameters -----------------------------------------------

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,4 @@
+url: https://mrc-ide.github.io/malariasimple/
+
+template:
+  bootstrap: 5

--- a/inst/odin/malariasimple_deterministic.R
+++ b/inst/odin/malariasimple_deterministic.R
@@ -396,7 +396,7 @@ dim(FOIvijk) <- c(na,nh,num_int)
 omega <- parameter()
 FOIvijk[1:na, 1:nh, 1:num_int] <- ((cT*smc_rel_c_mask[i,j,k]*T[i,j,k] + cD*smc_rel_c_mask[i,j,k]*D[i,j,k] + cA[i,j,k]*smc_rel_c_mask[i,j,k]*A[i,j,k] + cU*smc_rel_c_mask[i,j,k]*U[i,j,k])/H) *
   rel_foi[j] * av_mosq[k]*foi_age[i]/omega ## For discrete human compartments
-lag_FOIv=sum(FOIvijk)
+lag_FOIv <- sum(FOIvijk)
 
 ince <- FOIv[lag_ratesMos] * lag_ratesMos/delayGam * Sv
 

--- a/inst/odin/malariasimple_stochastic.R
+++ b/inst/odin/malariasimple_stochastic.R
@@ -483,7 +483,7 @@ dim(FOIvijk) <- c(na,nh,num_int)
 omega <- parameter()
 FOIvijk[1:na, 1:nh, 1:num_int] <- ((cT*smc_rel_c_mask[i,j,k]*T[i,j,k] + cD*smc_rel_c_mask[i,j,k]*D[i,j,k] + cA[i,j,k]*smc_rel_c_mask[i,j,k]*A[i,j,k] + cU*smc_rel_c_mask[i,j,k]*U[i,j,k])/H) *
   rel_foi[j] * av_mosq[k]*foi_age[i]/omega ## For discrete human compartments
-lag_FOIv=sum(FOIvijk)
+lag_FOIv <- sum(FOIvijk)
 
 ince <- FOIv[lag_ratesMos] * lag_ratesMos/delayGam * Sv
 

--- a/man/get_custom.Rd
+++ b/man/get_custom.Rd
@@ -24,7 +24,12 @@ get_custom(
 
 \item{biting_groups}{Biting groups of interest}
 
-\item{int_groups}{Intervention groups of interest. 1 = No intervention, 2 = Bednets, 3 = SMC, 4 = Bednets and SMC}
+\item{int_groups}{Intervention groups of interest, given as indices into the
+model's intervention strata (1 = No intervention, 2 = Bednets, 3 = SMC,
+4 = Bednets and SMC). These indices reflect the interventions currently
+supported by the model (ITNs and SMC); adding a new intervention type would
+require extending the intervention structure in `set_equilibrium()` and the
+odin model, after which the index meanings would change accordingly.}
 }
 \description{
 Allows the user to filter to more specific human outputs. Aggregated values for any human compartment as well as

--- a/man/get_custom_output.Rd
+++ b/man/get_custom_output.Rd
@@ -24,7 +24,12 @@ get_custom_output(
 
 \item{biting_groups}{Biting groups of interest}
 
-\item{int_groups}{Intervention groups of interest. 1 = No intervention, 2 = Bednets, 3 = SMC, 4 = Bednets and SMC}
+\item{int_groups}{Intervention groups of interest, given as indices into the
+model's intervention strata (1 = No intervention, 2 = Bednets, 3 = SMC,
+4 = Bednets and SMC). These indices reflect the interventions currently
+supported by the model (ITNs and SMC); adding a new intervention type would
+require extending the intervention structure in `set_equilibrium()` and the
+odin model, after which the index meanings would change accordingly.}
 }
 \description{
 Allows the user to filter to more specific human outputs. Aggregated values for any human compartment as well as

--- a/man/malariasimple-package.Rd
+++ b/man/malariasimple-package.Rd
@@ -8,6 +8,14 @@
 \description{
 A faster, simpler implementation of malariasimulation built using the package 'odin.dust'.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/mrc-ide/malariasimple}
+  \item Report bugs at \url{https://github.com/mrc-ide/malariasimple/issues}
+}
+
+}
 \author{
 \strong{Maintainer}: Debbie Shackleton \email{dshackle@imperial.ac.uk}
 

--- a/tests/testthat/test-set_smc.R
+++ b/tests/testthat/test-set_smc.R
@@ -11,17 +11,25 @@ test_that("get_smc_usage_mat returns zero usage from zero coverage input",{
     n_days = 300,
     distribution_type = "random"
   )
-  smc_usage_mat_cohort <- get_smc_usage_mat(
+  smc_usage_mat_corr <- get_smc_usage_mat(
     days = c(10, 100, 200),
     coverages = c(0, 0, 0),
     n_days = 300,
-    distribution_type = "cohort"
+    distribution_type = "correlated"
   )
 
-  expect_true(all(smc_usage_mat_cohort[,4] == 1))
+  expect_true(all(smc_usage_mat_corr[,4] == 1))
   expect_true(all(smc_usage_mat_random[,4] == 1))
-  expect_true(all(smc_usage_mat_cohort[,1:3] == 0))
+  expect_true(all(smc_usage_mat_corr[,1:3] == 0))
   expect_true(all(smc_usage_mat_random[,1:3] == 0))
+})
+
+test_that("set_smc rejects an unsupported distribution_type", {
+  expect_error(
+    get_parameters(n_days = 200) |>
+      set_smc(days = c(50, 100), coverages = 0.5, distribution_type = "cohort"),
+    "distribution_type"
+  )
 })
 
 test_that("alpha_smc is zero when drug_efficacy is zero",{

--- a/vignettes/Basic_Model_Run.Rmd
+++ b/vignettes/Basic_Model_Run.Rmd
@@ -105,7 +105,7 @@ out_ages <- run_simulation(params_ages) |> as.data.frame()
 par(mfrow = c(1,2))
 plot(x = out_ages$time, y = out_ages$n_clin_inc_0_Inf / out_ages$n_0_Inf,
      type = "l", col = "#F8766D", ylim = c(0,0.0025),lwd = 2,
-     xlab = "Days", ylab = "Clinical Incidence")
+     xlab = "Days", ylab = "Clinical incidence (cases per person per day)")
 lines(out_ages$time, out_ages$n_clin_inc_730_3650 / out_ages$n_730_3650,
       col = "#00BFC4",lwd=2)
 legend("bottomright", legend = c("All ages", "Ages 2-10"),
@@ -124,7 +124,7 @@ legend("bottomright", legend = c("All ages", "Ages 2-10"),
 
 ## Plotting Age Distribution
 
-We can also use the age rendering function to plot the age distribution of certain outputs. Here we show an example of how to output the average age distribution of clinical incidence. 
+We can also use the age rendering function to plot the age distribution of certain outputs. Here we show an example of how to output the average age distribution of clinical incidence. As above, we report incidence per capita (cases per person per day) by dividing each age group's incidence count (`n_clin_inc_*`) by its population (`n_*`), so the values are on the same scale as the plots above.
 ```{r, message = FALSE, results = "hide", fig.align = 'center', out.width='100%', fig.asp=0.55}
 age_vector <- c(0:100) * 365
 min_age_render <- c(0:99) * 365
@@ -146,13 +146,21 @@ out_ages <- run_simulation(params_ages) |>
   as.data.frame()
 
 ## -------------------------- Plot age distribution  --------------------------
-col_means <- sapply(out_ages[, grepl("n_clin_inc", colnames(out_ages))], mean, na.rm = TRUE)
-names(col_means) <- NULL
+clin_cols <- grep("n_clin_inc", colnames(out_ages), value = TRUE)
+pop_cols  <- sub("n_clin_inc_", "n_", clin_cols)
+
+# Per-capita clinical incidence (cases per person per day), averaged over time
+age_means <- vapply(
+  seq_along(clin_cols),
+  function(i) mean(out_ages[[clin_cols[i]]] / out_ages[[pop_cols[i]]], na.rm = TRUE),
+  numeric(1)
+)
 barplot(
-  col_means,
+  age_means,
   col = "lightblue",
   main = "Average Clinical Incidence by Yearly Age Group",
-  ylab = "Average Incidence"
+  xlab = "Age group (years)",
+  ylab = "Clinical incidence (cases per person per day)"
 )
 ```
 

--- a/vignettes/ITN.Rmd
+++ b/vignettes/ITN.Rmd
@@ -187,6 +187,8 @@ plot(continuous_out$time, continuous_out$n_detect_730_3650/continuous_out$n_730_
 
 Under the continuous assumption, insecticide decay is considered constant (equal to mean decay over `retention` period). ITN coverage is input directly as a daily time series `daily_continuous_cov`.
 
+Below we overlay the total ITN usage (`daily_continuous_cov`) with the *mean ITN efficacy*: the daily probability that a host-seeking mosquito is killed or repelled (`1 - s_itn_daily`). This combines coverage with the (constant) mean insecticide effect, so it sits below the usage curve.
+
 ```{r, message = FALSE, results = "hide", fig.align = 'center', out.width='100%', fig.asp=0.6}
 ## -----------------------  Plot --------------------------------------
 par(cex = 0.8)
@@ -200,6 +202,13 @@ plot(
   lty = 2,
   lwd = 2
 )
+lines(
+  1:n_days,
+  1 - continuous_params$s_itn_daily[2:(n_days + 1)],
+  col = "red",
+  lty = 2,
+  lwd = 2
+)
 legend(
   "bottomright",
   legend = c("Total ITN usage", "Mean ITN efficacy"),
@@ -207,7 +216,7 @@ legend(
   lty = c(2, 2),
   lwd = c(2, 2),
   bty = "n"
-) 
+)
 ```
 
 

--- a/vignettes/custom_outputs.Rmd
+++ b/vignettes/custom_outputs.Rmd
@@ -73,7 +73,7 @@ smc_params <- malariasimple::get_parameters(n_days = 1000,
           days = smc_days,
           min_age = 1 * 365,
           max_age = 5*365,
-          distribution_type = "cohort") |>
+          distribution_type = "correlated") |>
   malariasimple::set_equilibrium(init_EIR = 30)
 
 #Run simulation with 'full_output = TRUE'
@@ -81,7 +81,11 @@ smc_sim <- malariasimple::run_simulation(smc_params, full_output = TRUE) |> as.d
 
 ## Get customised outputs
 #Define ages of interest (in this case, all age categories within the SMC age boundaries)
-smc_ages <- c(1, 2, 3) * 365 #Age categories are defined by their lower bound
+#Age categories are selected by their lower bound. Given the age_vector above
+#(...1, 2, 3, 5...), selecting lower bounds 1, 2 and 3 covers the bands [1,2),
+#[2,3) and [3,5) - i.e. ages 1 to 5 - which matches the SMC age range
+#(min_age = 1 year, max_age = 5 years) and the reported PfPR1-5.
+smc_ages <- c(1, 2, 3) * 365
 
 #Get output for children who have received SMC
 smc_kids <- get_custom_output(


### PR DESCRIPTION
This PR makes a set of documentation, robustness and infrastructure improvements. No changes are made to the model dynamics; for any valid model configuration, simulation outputs are unchanged.

## Vignettes

- **ITN** — The continuous-distribution example previously referenced a "Mean ITN efficacy" line in its legend that was never drawn. The plot now draws this series (the daily probability a host-seeking mosquito is killed or repelled, `1 - s_itn_daily`) alongside total ITN usage, with a short explanation of what it represents.
- **Basic model run** — Clinical incidence is now reported consistently as a per-capita rate (cases per person per day) with explicit units on every panel. The age-distribution bar plot previously plotted raw case counts, which differed from the line plots by orders of magnitude; it now divides each age group's incidence by that group's population so all panels are on the same scale. `sapply()` is replaced with a type-stable `vapply()`.
- **Custom outputs** — The SMC example now uses a supported `distribution_type` (`"correlated"`), so the SMC and non-SMC prevalence curves coincide until the first SMC round and then diverge as expected. A comment explains why selecting the age categories with lower bounds 1, 2 and 3 corresponds to PfPR over ages 1–5 for the chosen `age_vector`.

## Package

- **`set_smc()`** now validates `distribution_type` and raises a clear error for unsupported values, rather than silently producing an invalid coverage. This is the underlying cause of the SMC example above: an unsupported value was accepted and led to a coverage greater than one.
- **`get_custom_output()`** documentation now clarifies that `int_group` indices refer to the interventions the model currently supports (none / ITN / SMC / both), and that adding a new intervention type would require extending the intervention structure.
- The odin model definitions use `<-` for assignment consistently.
- `DESCRIPTION` gains `URL` and `BugReports` fields.

## Documentation website / CI

- A pkgdown workflow builds the package website on every push and pull request, and deploys it on merge to `main`, so the rendered vignettes stay current.
- Adds a minimal `_pkgdown.yml` and ignores the local `docs/` build directory.

## Verification

- Full test suite passes (81 checks), including a new test covering `set_smc()` input validation.
- All three updated vignettes were rebuilt and the figures inspected to confirm the intended output.